### PR TITLE
ISDK-2479: Straw man's fix for ReplayKit image corruption

### DIFF
--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -87,7 +87,7 @@ class SampleHandler: RPBroadcastSampleHandler, TVIRoomDelegate {
 
             /*
              * A broadcast extension has no need to subscribe to Tracks, and connects as a publish-only
-             * Participant. In a Group Room, this options saves memory and bandwidth since decoders and receivers are
+             * Participant. In a Group Room, this option saves memory and bandwidth since decoders and receivers are
              * no longer needed. Note that subscription events will not be raised for remote publications.
              */
             builder.isAutomaticSubscriptionEnabled = false

--- a/ReplayKitExample/README.md
+++ b/ReplayKitExample/README.md
@@ -54,8 +54,7 @@ Tapping "Start Conference" begins capturing and sharing the screen from within t
 
 1. Support capturing both application and microphone audio at the same time, in an extension. Down-mix the resulting audio samples into a single stream.
 2. Share the camera using ReplayKit, or `TVICameraSource`.
-3. Resolve tearing issues when scrolling vertically, and image corruption when sharing video. (ISDK-2478)
-4. Quantize ReplayKit video timestamps and use them to drop from 60 / 120 fps peaks to a lower rate (15 / 30).
+3. Quantize ReplayKit video timestamps and use them to drop from 60 / 120 fps peaks to a lower rate (15 / 30).
 
 ### Known Issues
 


### PR DESCRIPTION
I've long held a theory that ReplayKit.framework has a bug when it comes to (video) CMSampleBuffer reuse. This can cause image corruption, for example:

![replaykit-corruption-crop](https://user-images.githubusercontent.com/1302577/56708020-0b47db00-66d0-11e9-89af-d4861510a43c.png)

My theory is that as soon as ReplayKitVideoSource releases the CMSampleBuffer (but not the underlying CVPixelBuffer) ReplayKit.framework reclaims the CVPixelBuffer and may begin to write the next frame to it. Since the video pipeline locks the frame for reading (and retains it) ReplayKit should not be able to write to it during this time, but who knows what power the OS vendor might have. 😸 

**Simple Solution**

What if we just retained the last `CMSampleBuffer` from ReplayKit? Guess what, this solves the image corruption in the vast majority of cases.

**Final Solution**

What would a production worthy implementation look like? We might want to tie the lifecycle of the CMSampleBuffer to the CVPixelBuffer. Perhaps ReplayKitVideoSource could register a callback when the pixel buffer is destroyed that would actually invert the ownership to workaround the bug in ReplayKit.

TODO

* [ ] Try a solution which extends the lifetime of CMSampleBuffer correctly in all cases