### PR TITLE
ISDK-2555: Update Quickstart for 3.0.0-beta2

### DIFF
--- a/AVPlayerExample/ViewController.m
+++ b/AVPlayerExample/ViewController.m
@@ -79,7 +79,7 @@ NSString *const kStatusKey   = @"status";
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    [self logMessage:[NSString stringWithFormat:@"TwilioVideo v%@", [TwilioVideoSDK version]]];
+    [self logMessage:[NSString stringWithFormat:@"TwilioVideo v%@", [TwilioVideoSDK sdkVersion]]];
 
     // Configure access token for testing. Create one manually in the console
     // at https://www.twilio.com/console/video/runtime/testing-tools
@@ -452,7 +452,7 @@ NSString *const kStatusKey   = @"status";
 #pragma mark - TVIRemoteParticipantDelegate
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-      publishedVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+     didPublishVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     
     // Remote Participant has offered to share the video Track.
     
@@ -460,7 +460,7 @@ NSString *const kStatusKey   = @"status";
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-    unpublishedVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+   didUnpublishVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     
     // Remote Participant has stopped sharing the video Track.
     
@@ -468,7 +468,7 @@ NSString *const kStatusKey   = @"status";
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-      publishedAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+     didPublishAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     
     // Remote Participant has offered to share the audio Track.
     
@@ -476,16 +476,16 @@ NSString *const kStatusKey   = @"status";
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-    unpublishedAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+   didUnpublishAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     
     // Remote Participant has stopped sharing the audio Track.
     
     [self logMessage:[NSString stringWithFormat:@"Participant %@ unpublished audio track.", participant.identity]];
 }
 
-- (void)subscribedToVideoTrack:(TVIRemoteVideoTrack *)videoTrack
-                   publication:(TVIRemoteVideoTrackPublication *)publication
-                forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didSubscribeToVideoTrack:(TVIRemoteVideoTrack *)videoTrack
+                     publication:(TVIRemoteVideoTrackPublication *)publication
+                  forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are subscribed to the remote Participant's audio Track. We will start receiving the
     // remote Participant's video frames now.
@@ -498,9 +498,9 @@ NSString *const kStatusKey   = @"status";
     }
 }
 
-- (void)unsubscribedFromVideoTrack:(TVIRemoteVideoTrack *)videoTrack
-                       publication:(TVIRemoteVideoTrackPublication *)publication
-                    forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didUnsubscribeFromVideoTrack:(TVIRemoteVideoTrack *)videoTrack
+                         publication:(TVIRemoteVideoTrackPublication *)publication
+                      forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are unsubscribed from the remote Participant's video Track. We will no longer receive the
     // remote Participant's video.
@@ -513,9 +513,9 @@ NSString *const kStatusKey   = @"status";
     }
 }
 
-- (void)subscribedToAudioTrack:(TVIRemoteAudioTrack *)audioTrack
-                   publication:(TVIRemoteAudioTrackPublication *)publication
-                forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didSubscribeToAudioTrack:(TVIRemoteAudioTrack *)audioTrack
+                     publication:(TVIRemoteAudioTrackPublication *)publication
+                  forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are subscribed to the remote Participant's audio Track. We will start receiving the
     // remote Participant's audio now.
@@ -523,9 +523,9 @@ NSString *const kStatusKey   = @"status";
     [self logMessage:[NSString stringWithFormat:@"Subscribed to audio track for Participant %@", participant.identity]];
 }
 
-- (void)unsubscribedFromAudioTrack:(TVIRemoteAudioTrack *)audioTrack
-                       publication:(TVIRemoteAudioTrackPublication *)publication
-                    forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didUnsubscribeFromAudioTrack:(TVIRemoteAudioTrack *)audioTrack
+                         publication:(TVIRemoteAudioTrackPublication *)publication
+                      forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are unsubscribed from the remote Participant's audio Track. We will no longer receive the
     // remote Participant's audio.
@@ -534,35 +534,35 @@ NSString *const kStatusKey   = @"status";
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-        enabledVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+      didEnableVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ enabled video track.", participant.identity]];
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-       disabledVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+     didDisableVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ disabled video track.", participant.identity]];
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-        enabledAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+      didEnableAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ enabled audio track.", participant.identity]];
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-       disabledAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+     didDisableAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ disabled audio track.", participant.identity]];
 }
 
-- (void)failedToSubscribeToAudioTrack:(TVIRemoteAudioTrackPublication *)publication
-                                error:(NSError *)error
-                       forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didFailToSubscribeToAudioTrack:(TVIRemoteAudioTrackPublication *)publication
+                                 error:(NSError *)error
+                        forParticipant:(TVIRemoteParticipant *)participant {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ failed to subscribe to %@ audio track.",
                       participant.identity, publication.trackName]];
 }
 
-- (void)failedToSubscribeToVideoTrack:(TVIRemoteVideoTrackPublication *)publication
-                                error:(NSError *)error
-                       forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didFailToSubscribeToVideoTrack:(TVIRemoteVideoTrackPublication *)publication
+                                 error:(NSError *)error
+                        forParticipant:(TVIRemoteParticipant *)participant {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ failed to subscribe to %@ video track.",
                       participant.identity, publication.trackName]];
 }

--- a/MultiPartyExample/MainViewController.swift
+++ b/MultiPartyExample/MainViewController.swift
@@ -54,7 +54,7 @@ class MainViewController: UIViewController {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         roomTextField?.text = ""
-        logMessage(messageText: "Twilio Video v\(TwilioVideoSDK.version())")
+        logMessage(messageText: "Twilio Video v\(TwilioVideoSDK.sdkVersion())")
     }
 
     @objc func dismissKeyboard() {

--- a/MultiPartyExample/MultiPartyViewController.swift
+++ b/MultiPartyExample/MultiPartyViewController.swift
@@ -36,7 +36,7 @@ class MultiPartyViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        logMessage(messageText: "TwilioVideo v(\(TwilioVideoSDK.version()))")
+        logMessage(messageText: "TwilioVideo v(\(TwilioVideoSDK.sdkVersion()))")
 
         title = roomName
         navigationItem.setHidesBackButton(true, animated: false)

--- a/ObjCVideoQuickstart/ViewController.m
+++ b/ObjCVideoQuickstart/ViewController.m
@@ -47,7 +47,7 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
 
-    [self logMessage:[NSString stringWithFormat:@"TwilioVideo v%@", [TwilioVideoSDK version]]];
+    [self logMessage:[NSString stringWithFormat:@"TwilioVideo v%@", [TwilioVideoSDK sdkVersion]]];
 
     // Configure access token for testing. Create one manually in the console
     // at https://www.twilio.com/console/video/runtime/testing-tools
@@ -366,7 +366,7 @@
 #pragma mark - TVIRemoteParticipantDelegate
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-      publishedVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+     didPublishVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     
     // Remote Participant has offered to share the video Track.
 
@@ -375,7 +375,7 @@
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-    unpublishedVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+   didUnpublishVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     
     // Remote Participant has stopped sharing the video Track.
     
@@ -384,7 +384,7 @@
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-      publishedAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+     didPublishAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     
     // Remote Participant has offered to share the audio Track.
     
@@ -393,7 +393,7 @@
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-    unpublishedAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+   didUnpublishAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     
     // Remote Participant has stopped sharing the audio Track.
     
@@ -401,9 +401,9 @@
                       participant.identity, publication.trackName]];
 }
 
-- (void)subscribedToVideoTrack:(TVIRemoteVideoTrack *)videoTrack
-                   publication:(TVIRemoteVideoTrackPublication *)publication
-                forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didSubscribeToVideoTrack:(TVIRemoteVideoTrack *)videoTrack
+                     publication:(TVIRemoteVideoTrackPublication *)publication
+                  forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are subscribed to the remote Participant's audio Track. We will start receiving the
     // remote Participant's video frames now.
@@ -417,9 +417,9 @@
     }
 }
 
-- (void)unsubscribedFromVideoTrack:(TVIRemoteVideoTrack *)videoTrack
-                       publication:(TVIRemoteVideoTrackPublication *)publication
-                    forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didUnsubscribeFromVideoTrack:(TVIRemoteVideoTrack *)videoTrack
+                         publication:(TVIRemoteVideoTrackPublication *)publication
+                      forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are unsubscribed from the remote Participant's video Track. We will no longer receive the
     // remote Participant's video.
@@ -433,9 +433,9 @@
     }
 }
 
-- (void)subscribedToAudioTrack:(TVIRemoteAudioTrack *)audioTrack
-                   publication:(TVIRemoteAudioTrackPublication *)publication
-                forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didSubscribeToAudioTrack:(TVIRemoteAudioTrack *)audioTrack
+                     publication:(TVIRemoteAudioTrackPublication *)publication
+                  forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are subscribed to the remote Participant's audio Track. We will start receiving the
     // remote Participant's audio now.
@@ -444,9 +444,9 @@
                       publication.trackName, participant.identity]];
 }
 
-- (void)unsubscribedFromAudioTrack:(TVIRemoteAudioTrack *)audioTrack
-                       publication:(TVIRemoteAudioTrackPublication *)publication
-                    forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didUnsubscribeFromAudioTrack:(TVIRemoteAudioTrack *)audioTrack
+                         publication:(TVIRemoteAudioTrackPublication *)publication
+                      forParticipant:(TVIRemoteParticipant *)participant {
     
     // We are unsubscribed from the remote Participant's audio Track. We will no longer receive the
     // remote Participant's audio.
@@ -456,39 +456,39 @@
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-        enabledVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+      didEnableVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ enabled %@ video track.",
                       participant.identity, publication.trackName]];
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-       disabledVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
+     didDisableVideoTrack:(TVIRemoteVideoTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ disabled %@ video track.",
                       participant.identity, publication.trackName]];
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-        enabledAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+      didEnableAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ enabled %@ audio track.",
                       participant.identity, publication.trackName]];
 }
 
 - (void)remoteParticipant:(TVIRemoteParticipant *)participant
-       disabledAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
+     didDisableAudioTrack:(TVIRemoteAudioTrackPublication *)publication {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ disabled %@ audio track.",
                       participant.identity, publication.trackName]];
 }
 
-- (void)failedToSubscribeToAudioTrack:(TVIRemoteAudioTrackPublication *)publication
-                                error:(NSError *)error
-                       forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didFailToSubscribeToAudioTrack:(TVIRemoteAudioTrackPublication *)publication
+                                 error:(NSError *)error
+                        forParticipant:(TVIRemoteParticipant *)participant {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ failed to subscribe to %@ audio track.",
                       participant.identity, publication.trackName]];
 }
 
-- (void)failedToSubscribeToVideoTrack:(TVIRemoteVideoTrackPublication *)publication
-                                error:(NSError *)error
-                       forParticipant:(TVIRemoteParticipant *)participant {
+- (void)didFailToSubscribeToVideoTrack:(TVIRemoteVideoTrackPublication *)publication
+                                 error:(NSError *)error
+                        forParticipant:(TVIRemoteParticipant *)participant {
     [self logMessage:[NSString stringWithFormat:@"Participant %@ failed to subscribe to %@ video track.",
                       participant.identity, publication.trackName]];
 }

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 3.0.0-beta1'
+  pod 'TwilioVideo', '~> 3.0.0-beta2'
 
   target 'ARKitExample' do
     platform :ios, '11.0'

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 
-[ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://github.com/twilio/twilio-video-ios/releases/download/3.0.0-beta1/TwilioVideo.framework.zip)
-[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/3.0.0-beta1/index.html)
+[ ![Download](https://img.shields.io/badge/Download-iOS%20SDK-blue.svg) ](https://github.com/twilio/twilio-video-ios/releases/download/3.0.0-beta2/TwilioVideo.framework.zip)
+[![Docs](https://img.shields.io/badge/iOS%20Docs-OK-blue.svg)](https://twilio.github.io/twilio-video-ios/docs/3.0.0-beta2/index.html)
 
 # Twilio Video Quickstart for iOS
 
@@ -150,7 +150,7 @@ For this Quickstart, the Application transport security settings are set to allo
 You can find more documentation on getting started as well as our latest Docs below:
 
 * [Getting Started](https://www.twilio.com/docs/video/ios-v3-getting-started)
-* [Docs](https://twilio.github.io/twilio-video-ios/docs/3.0.0-beta1/index.html)
+* [Docs](https://twilio.github.io/twilio-video-ios/docs/3.0.0-beta2/index.html)
 
 ## Issues and Support
 

--- a/ReplayKitExample/BroadcastExtension/SampleHandler.swift
+++ b/ReplayKitExample/BroadcastExtension/SampleHandler.swift
@@ -19,7 +19,7 @@ class SampleHandler: RPBroadcastSampleHandler {
     var disconnectSemaphore: DispatchSemaphore?
 
     var accessToken: String = "TWILIO_ACCESS_TOKEN"
-    let accessTokenUrl = "http://127.0.0.1:5000/"
+    let tokenUrl = "http://127.0.0.1:5000/"
 
     static let kBroadcastSetupInfoRoomNameKey = "roomName"
 
@@ -39,7 +39,7 @@ class SampleHandler: RPBroadcastSampleHandler {
         // User has requested to start the broadcast. Setup info from the UI extension can be supplied but is optional.
         if (accessToken == "TWILIO_ACCESS_TOKEN" || accessToken.isEmpty) {
             do {
-                accessToken = try TokenUtils.fetchToken(url: self.accessTokenUrl)
+                accessToken = try TokenUtils.fetchToken(url: self.tokenUrl)
             } catch {
                 let message = "Failed to fetch access token."
                 print(message)

--- a/ReplayKitExample/ReplayKitExample/ViewController.swift
+++ b/ReplayKitExample/ReplayKitExample/ViewController.swift
@@ -28,7 +28,7 @@ class ViewController: UIViewController {
     var broadcastController: RPBroadcastController?
 
     var accessToken: String = "TWILIO_ACCESS_TOKEN"
-    let accessTokenUrl = "http://127.0.0.1:5000/"
+    let tokenUrl = "http://127.0.0.1:5000/"
 
     static let kBroadcastExtensionBundleId = "com.twilio.ReplayKitExample.BroadcastVideoExtension"
     static let kBroadcastExtensionSetupUiBundleId = "com.twilio.ReplayKitExample.BroadcastVideoExtensionSetupUI"
@@ -319,7 +319,7 @@ class ViewController: UIViewController {
         // If the default wasn't changed, try fetching from server.
         if (accessToken == "TWILIO_ACCESS_TOKEN" || accessToken.isEmpty) {
             do {
-                accessToken = try TokenUtils.fetchToken(url: accessTokenUrl)
+                accessToken = try TokenUtils.fetchToken(url: tokenUrl)
             } catch {
                 stopConference(error: error)
                 return

--- a/Utils/SettingsTableViewController.swift
+++ b/Utils/SettingsTableViewController.swift
@@ -10,13 +10,13 @@ import TwilioVideo
 
 class SettingsTableViewController: UITableViewController {
     
-    static let signalingRegionLabel = "Signaling Region"
+    static let signalingRegionLabel = "Region"
     static let audioCodecLabel = "Audio Codec"
     static let videoCodecLabel = "Video Codec"
     static let maxAudioBitrateLabel = "Max Audio Bitrate (bps)"
     static let maxVideoBitrateLabel = "Max Video Bitrate (bps)"
     static let defaultStr = "Default"
-    static let signalingRegionDisclaimerText = "Set your preferred signaling region. Global Low Latency (gll) is the default value."
+    static let signalingRegionDisclaimerText = "Set your preferred region. Global Low Latency (gll) is the default value."
     static let codecDisclaimerText = "Set your preferred audio and video codec. Not all codecs are supported in Group Rooms. The media server will fallback to OPUS or VP8 if a preferred codec is not supported. VP8 Simulcast should only be enabled in a Group Room."
     static let encodingParamsDisclaimerText = "Set sender bandwidth constraints. Zero represents the WebRTC default which varies by codec."
     


### PR DESCRIPTION
This PR updates the Quickstarts for the `3.0.0-beta2` API changes:

- `TwilioVideoSDK.version` => `TwilioVideoSDK.sdkVersion`
- Updates for the renaming of the `TVIRemoteParticipantDelegate` methods
- Updates `Podfile` and `README.md` for `3.0.0-beta2`

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
