### PR TITLE
ISDK-2169, ISDK-2653: Simulate incoming CallKit calls in the background

### DIFF
--- a/VideoCallKitQuickStart/Base.lproj/Main.storyboard
+++ b/VideoCallKitQuickStart/Base.lproj/Main.storyboard
@@ -49,7 +49,7 @@
                                     <constraint firstAttribute="height" constant="44" id="ZbX-w3-djY"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                <state key="normal" title="Simulate Incoming Call">
+                                <state key="normal" title="Schedule Notification">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                                 <connections>

--- a/VideoCallKitQuickStart/ViewController+SimulateIncomingCall.swift
+++ b/VideoCallKitQuickStart/ViewController+SimulateIncomingCall.swift
@@ -13,8 +13,8 @@ extension ViewController {
 
     func registerForLocalNotifications() {
         // Define the custom actions.
-        let acceptAction = UNNotificationAction(identifier: "ACCEPT_ACTION",
-              title: "Accept",
+        let inviteAction = UNNotificationAction(identifier: "INVITE_ACTION",
+              title: "Simulate VoIP Push",
               options: UNNotificationActionOptions(rawValue: 0))
         let declineAction = UNNotificationAction(identifier: "DECLINE_ACTION",
               title: "Decline",
@@ -25,7 +25,7 @@ extension ViewController {
         if #available(iOS 11.0, *) {
             let meetingInviteCategory =
                 UNNotificationCategory(identifier: "ROOM_INVITATION",
-                                       actions: [acceptAction, declineAction],
+                                       actions: [inviteAction, declineAction],
                                        intentIdentifiers: [],
                                        hiddenPreviewsBodyPlaceholder: "",
                                        options: .customDismissAction)
@@ -112,12 +112,10 @@ extension ViewController : UNUserNotificationCenterDelegate {
 
         switch response.actionIdentifier {
         case UNNotificationDefaultActionIdentifier:
-            self.reportIncomingCall(uuid: UUID(), roomName: self.roomTextField.text) { _ in
-                // Always call the completion handler when done.
-                completionHandler()
-            }
+            self.performStartCallAction(uuid: UUID(), roomName: self.roomTextField.text)
+            completionHandler()
             break
-        case "ACCEPT_ACTION":
+        case "INVITE_ACTION":
             self.reportIncomingCall(uuid: UUID(), roomName: self.roomTextField.text) { _ in
                 // Always call the completion handler when done.
                 completionHandler()

--- a/VideoCallKitQuickStart/ViewController+SimulateIncomingCall.swift
+++ b/VideoCallKitQuickStart/ViewController+SimulateIncomingCall.swift
@@ -22,17 +22,13 @@ extension ViewController {
         let notificationCenter = UNUserNotificationCenter.current()
 
         // Define the notification type
-        if #available(iOS 11.0, *) {
-            let meetingInviteCategory =
-                UNNotificationCategory(identifier: "ROOM_INVITATION",
-                                       actions: [inviteAction, declineAction],
-                                       intentIdentifiers: [],
-                                       hiddenPreviewsBodyPlaceholder: "",
-                                       options: .customDismissAction)
-            notificationCenter.setNotificationCategories([meetingInviteCategory])
-        }
+        let meetingInviteCategory = UNNotificationCategory(identifier: "ROOM_INVITATION",
+                                                           actions: [inviteAction, declineAction],
+                                                           intentIdentifiers: [],
+                                                           options: .customDismissAction)
+        notificationCenter.setNotificationCategories([meetingInviteCategory])
 
-        // Register the notification type.
+        // Register for notification callbacks.
         notificationCenter.delegate = self
 
         // Request permission to display alerts and play sounds.

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -103,6 +103,8 @@ class ViewController: UIViewController {
         
         let tap = UITapGestureRecognizer(target: self, action: #selector(ViewController.dismissKeyboard))
         self.view.addGestureRecognizer(tap)
+
+        self.registerForLocalNotifications()
     }
 
     override var prefersHomeIndicatorAutoHidden: Bool {


### PR DESCRIPTION
This PR makes simulation of incoming calls in VideoCallKitQuickstart more powerful by adopting the [UserNotifications](https://developer.apple.com/documentation/usernotifications) framework. This allows the following inbound scenarios to be tested:

1. Application is active.
2. Application is inactive and foregrounded.
3. Application is background.

An accept/decline UI is presented. The accept action does not require foregrounding the app, allowing it to be delivered in the background. The default action foregrounds the app.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
