### PR TITLE
ISDK-2659: Cross link to iOS 13 migration guide (master)

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@
 # Twilio Video Quickstart for iOS
 
 > NOTE: These sample applications use the Twilio Video 2.x APIs. For examples using our 3.0.0-beta APIs, please see the [3.0.0-beta](https://github.com/twilio/video-quickstart-ios/tree/3.0.0-beta) branch. For examples using our 1.x APIs, please see the [1.x](https://github.com/twilio/video-quickstart-ios/tree/1.x) branch.
+> 
+> Please see our [iOS 13 Migration Guide](https://github.com/twilio/twilio-video-ios/blob/Releases/iOS-13-Migration-Guide.md) for the latest information on iOS 13 and iPadOS 13.
 
 Get started with Video on iOS:
 
@@ -151,6 +153,7 @@ You can find more documentation on getting started as well as our latest Docs be
 
 * [Getting Started](https://www.twilio.com/docs/video/ios-v2-getting-started)
 * [Docs](https://twilio.github.io/twilio-video-ios/docs/latest/index.html)
+* [iOS 13 Migration Guide](https://github.com/twilio/twilio-video-ios/blob/Releases/iOS-13-Migration-Guide.md)
 
 ## Issues and Support
 

--- a/ReplayKitExample/README.md
+++ b/ReplayKitExample/README.md
@@ -75,7 +75,7 @@ It is not possible to capture application audio produced by AVPlayer, by Safari 
 
 **3. RPSystemBroadcastPickerView crashes (iOS 13.0-beta8)**
 
-There is a [serious bug](https://stackoverflow.com/questions/57163212/get-nsinvalidargumentexception-when-trying-to-present-rpsystembroadcastpickervie) in iOS 13.0-beta8 where tapping `RPSystemBroadcastPickerView` throws an exception. Since the issue is specific to iOS 13.0, and is fixed in 13.1-beta2, the example disables usage of the picker in the iOS 13.0.x.
+There is a [serious bug](https://stackoverflow.com/questions/57163212/get-nsinvalidargumentexception-when-trying-to-present-rpsystembroadcastpickervie) in iOS 13.0-beta8 where tapping `RPSystemBroadcastPickerView` throws an exception. Since the issue is specific to iOS 13.0, and is fixed in 13.1-beta2, the example disables usage of the picker on iOS 13.0.x releases.
 
 > *** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: 'Application tried to present UIModalTransitionStylePartialCurl to or from non-fullscreen view controller <UIApplicationRotationFollowingController: 0x104f31220>.'
 


### PR DESCRIPTION
Add a cross-link to the iOS 13 migration guide in the opening notice, and in the **More Documentation** section. This PR is for master, for 3.0.0-beta see https://github.com/twilio/video-quickstart-ios/pull/421.

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.