### PR TITLE
ISDK-2635: Use UIScene (single window) on iOS 13

### DIFF
--- a/VideoQuickStart.xcodeproj/project.pbxproj
+++ b/VideoQuickStart.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		4B63DD331F73032D00F0737E /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B63DD321F73032D00F0737E /* SettingsTableViewController.swift */; };
 		4B63DD381F730C1A00F0737E /* Settings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B63DD371F730C1A00F0737E /* Settings.swift */; };
 		4BAA74EB1D8B5CBE00239F19 /* Utils.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BAA74EA1D8B5CBE00239F19 /* Utils.swift */; };
+		8AE134702329DE8300E7DA1A /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AE1346F2329DE8300E7DA1A /* SceneDelegate.swift */; };
 		8B79D46A1C2252A100489AA5 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B79D4691C2252A100489AA5 /* AppDelegate.swift */; };
 		8B79D46C1C2252A100489AA5 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B79D46B1C2252A100489AA5 /* ViewController.swift */; };
 		8B79D46F1C2252A100489AA5 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 8B79D46D1C2252A100489AA5 /* Main.storyboard */; };
@@ -50,6 +51,7 @@
 		4B63DD321F73032D00F0737E /* SettingsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewController.swift; sourceTree = "<group>"; };
 		4B63DD371F730C1A00F0737E /* Settings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Settings.swift; sourceTree = "<group>"; };
 		4BAA74EA1D8B5CBE00239F19 /* Utils.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utils.swift; sourceTree = "<group>"; };
+		8AE1346F2329DE8300E7DA1A /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
 		8B79D4661C2252A100489AA5 /* VideoQuickStart.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = VideoQuickStart.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		8B79D4691C2252A100489AA5 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		8B79D46B1C2252A100489AA5 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
@@ -144,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				8B79D4691C2252A100489AA5 /* AppDelegate.swift */,
+				8AE1346F2329DE8300E7DA1A /* SceneDelegate.swift */,
 				8B79D46B1C2252A100489AA5 /* ViewController.swift */,
 			);
 			name = Source;
@@ -237,6 +240,7 @@
 				8B79D46A1C2252A100489AA5 /* AppDelegate.swift in Sources */,
 				4BAA74EB1D8B5CBE00239F19 /* Utils.swift in Sources */,
 				4B63DD381F730C1A00F0737E /* Settings.swift in Sources */,
+				8AE134702329DE8300E7DA1A /* SceneDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/VideoQuickStart/AppDelegate.swift
+++ b/VideoQuickStart/AppDelegate.swift
@@ -10,14 +10,30 @@ import UIKit
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
-  var window: UIWindow?
+    var window: UIWindow?
 
-  func application(_ application: UIApplication,
-      didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    // Override point for customization after application launch.
-    
-    return true
-  }
+    func application(_ application: UIApplication,
+                     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
 
+        return true
+    }
+
+    // These methods will not be called on iOS 13 where the SceneDelegate is invoked instead.
+    func applicationDidBecomeActive(_ application: UIApplication) {
+        print(#function)
+    }
+
+    func applicationWillResignActive(_ application: UIApplication) {
+        print(#function)
+    }
+
+    func applicationDidEnterBackground(_ application: UIApplication) {
+        print(#function)
+    }
+
+    func applicationWillEnterForeground(_ application: UIApplication) {
+        print(#function)
+    }
 }
 

--- a/VideoQuickStart/Info.plist
+++ b/VideoQuickStart/Info.plist
@@ -56,5 +56,24 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>VideoQuickStart.SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
 </dict>
 </plist>

--- a/VideoQuickStart/SceneDelegate.swift
+++ b/VideoQuickStart/SceneDelegate.swift
@@ -51,14 +51,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     func configure(window: UIWindow?, with activity: NSUserActivity) -> Bool {
         if activity.title == "Room" {
             if let roomName = activity.userInfo?["RoomName"] as? String {
-//                if let photoDetailViewController = PhotoDetailViewController.loadFromStoryboard() {
-//                    photoDetailViewController.photo = Photo(name: photoID)
-//
-//                    if let navigationController = window?.rootViewController as? UINavigationController {
-//                        navigationController.pushViewController(photoDetailViewController, animated: false)
-//                        return true
-//                    }
-//                }
+                // TODO: Allow connecting directly to a named Room.
             }
         }
         return false

--- a/VideoQuickStart/SceneDelegate.swift
+++ b/VideoQuickStart/SceneDelegate.swift
@@ -1,0 +1,67 @@
+//
+//  SceneDelegate.swift
+//  VideoQuickStart
+//
+//  Created by Chris Eagleston on 9/11/19.
+//  Copyright © 2019 Twilio, Inc. All rights reserved.
+//
+
+import UIKit
+
+@available(iOS 13.0, *)
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+    // UIWindowScene delegate
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        if let userActivity = connectionOptions.userActivities.first ?? session.stateRestorationActivity {
+            if !configure(window: window, with: userActivity) {
+                print("Failed to restore from \(userActivity)")
+            }
+        }
+
+        // If there were no user activities, we don't have to do anything.
+        // The `window` property will automatically be loaded with the storyboard's initial view controller.
+    }
+
+    func stateRestorationActivity(for scene: UIScene) -> NSUserActivity? {
+        return scene.userActivity
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        print(#function)
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        print(#function)
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        print(#function)
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        print(#function)
+    }
+
+    // Utilities
+
+    func configure(window: UIWindow?, with activity: NSUserActivity) -> Bool {
+        if activity.title == "Room" {
+            if let roomName = activity.userInfo?["RoomName"] as? String {
+//                if let photoDetailViewController = PhotoDetailViewController.loadFromStoryboard() {
+//                    photoDetailViewController.photo = Photo(name: photoID)
+//
+//                    if let navigationController = window?.rootViewController as? UINavigationController {
+//                        navigationController.pushViewController(photoDetailViewController, animated: false)
+//                        return true
+//                    }
+//                }
+            }
+        }
+        return false
+    }
+
+}


### PR DESCRIPTION
I'm posting this PR as a draft for discussion, as I expect that we will want to adopt the UIScene APIs on iOS 13, while continuing to support UIApplication based flows on earlier iOS versions.

The PR adds basic support for UIScene in iOS 13, but without enabling multiple window mode in the QS app. I used a plist to specify the default scene to be more friendly. iOS 12 behavior is not modified, and continues to use UIApplicationDelegate for UI events.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
