### PR TITLE
ISDK-2656: Recommend CocoaPods 1.7.5 or newer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@ If you haven't used Twilio before, welcome! You'll need to [Sign up for a Twilio
 
 ### CocoaPods
 
-1. Install [CocoaPods 1.0.0+](https://guides.cocoapods.org/using/getting-started.html).
+1. Install [CocoaPods 1.7.0 or newer](https://guides.cocoapods.org/using/getting-started.html).
 
-1. Run `pod install` from the root directory of this project. CocoaPods will install `TwilioVideo.framework` and then set up an `xcworkspace`.
+2. Run `pod install` from the root directory of this project. CocoaPods will install `TwilioVideo.framework` and then set up an `xcworkspace`.
 
-1. Open `VideoQuickStart.xcworkspace`.
+3. Open `VideoQuickStart.xcworkspace`.
 
 Note: You may need to update the CocoaPods [Master Spec Repo](https://github.com/CocoaPods/Specs) by running `pod repo update master` in order to fetch the latest specs for TwilioVideo.
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ If you haven't used Twilio before, welcome! You'll need to [Sign up for a Twilio
 
 ### CocoaPods
 
-1. Install [CocoaPods 1.7.0 or newer](https://guides.cocoapods.org/using/getting-started.html).
+1. Install [CocoaPods 1.7.5 or newer](https://guides.cocoapods.org/using/getting-started.html).
 
 2. Run `pod install` from the root directory of this project. CocoaPods will install `TwilioVideo.framework` and then set up an `xcworkspace`.
 


### PR DESCRIPTION
Using CocoaPods 1.7.5 resolves duplicate category definition warnings, which sometimes cause prefix header compilation to fail. For example when using CocoaPods 1.5.3 with Xcode 11:

[Build target AudioDeviceExample_2019-09-19T13-13-02.txt](https://github.com/twilio/video-quickstart-ios/files/3633866/Build.target.AudioDeviceExample_2019-09-19T13-13-02.txt)

Earlier versions of CocoaPods define both `HEADER_SEARCH_PATHS` and `FRAMEWORK_SEARCH_PATHS` for TwilioVideo.framework causing the duplicates to be found in AudioDeviceExample, and other targets that use a Swift bridging header.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.