### PR TITLE
ISDK-2679: Temporarily enforce Light mode

### DIFF
--- a/ARKitExample/Info.plist
+++ b/ARKitExample/Info.plist
@@ -53,5 +53,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/AVPlayerExample/Info.plist
+++ b/AVPlayerExample/Info.plist
@@ -54,5 +54,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/AudioDeviceExample/Info.plist
+++ b/AudioDeviceExample/Info.plist
@@ -55,5 +55,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/AudioSinkExample/Info.plist
+++ b/AudioSinkExample/Info.plist
@@ -54,5 +54,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/DataTrackExample/Info.plist
+++ b/DataTrackExample/Info.plist
@@ -43,5 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/MultiPartyExample/Info.plist
+++ b/MultiPartyExample/Info.plist
@@ -57,5 +57,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/ObjCVideoQuickstart/Info.plist
+++ b/ObjCVideoQuickstart/Info.plist
@@ -56,5 +56,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/ReplayKitExample/ReplayKitExample/Info.plist
+++ b/ReplayKitExample/ReplayKitExample/Info.plist
@@ -48,5 +48,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/ScreenCapturerExample/Info.plist
+++ b/ScreenCapturerExample/Info.plist
@@ -43,5 +43,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/VideoCallKitQuickStart/Info.plist
+++ b/VideoCallKitQuickStart/Info.plist
@@ -57,5 +57,7 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>

--- a/VideoQuickStart/Info.plist
+++ b/VideoQuickStart/Info.plist
@@ -75,5 +75,7 @@
 			</array>
 		</dict>
 	</dict>
+	<key>UIUserInterfaceStyle</key>
+	<string>Light</string>
 </dict>
 </plist>


### PR DESCRIPTION
Presently the QuickStart apps don't behave well when run on an iOS 13 device in Dark Mode. This is a temporary measure to ensure the apps behave as expected until we have a chance to better support Dark Mode in the apps.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
