### PR TITLE
ISDK-2603: Update 1.x docs to reference the 3.0 docs and fix some links

### DIFF
--- a/ARKitExample/README.md
+++ b/ARKitExample/README.md
@@ -4,7 +4,7 @@ The project demonstrates how to use Twilio's Programmable Video SDK to stream an
 
 ### Setup
 
-See the master [README](https://github.com/twilio/video-quickstart-ios/blob/master/README.md) for instructions on how to generate access tokens and connect to a Room.
+See the master [README](https://github.com/twilio/video-quickstart-ios/blob/1.x/README.md) for instructions on how to generate access tokens and connect to a Room.
 
 This example requires Xcode 9.0, and the iOS 11.0 SDK. An iOS device with an A9 CPU or greater is needed for ARKit to function properly.
 

--- a/AVPlayerExample/README.md
+++ b/AVPlayerExample/README.md
@@ -4,7 +4,7 @@ This example demonstrates how to use `AVPlayer` to stream Audio & Video content 
 
 ### Setup
 
-See the master [README](https://github.com/twilio/video-quickstart-ios/blob/master/README.md) for instructions on how to generate access tokens and connect to a Room.
+See the master [README](https://github.com/twilio/video-quickstart-ios/blob/1.x/README.md) for instructions on how to generate access tokens and connect to a Room.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -162,4 +162,4 @@ For general inquiries related to the Video SDK you can file a [support ticket](h
 
 ## License
 
-[MIT License](https://github.com/twilio/video-quickstart-ios/blob/master/LICENSE)
+[MIT License](https://github.com/twilio/video-quickstart-ios/blob/1.x/LICENSE)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # Twilio Video Quickstart for iOS
 
-> NOTE: These sample applications use the Twilio Video 1.x APIs. For examples using our 2.x APIs, please see the [master](https://github.com/twilio/video-quickstart-ios/tree/master) branch.
+> NOTE: These sample applications use the Twilio Video 1.x APIs. For examples using our 3.x APIs, please see the [master](https://github.com/twilio/video-quickstart-ios/tree/master) branch. For examples using our 2.x APIs, please see the [2.x](https://github.com/twilio/video-quickstart-ios/tree/2.x) branch.
 >
 > **Deprecation Notice - Versions 1.0.0-beta9 and earlier**
 >


### PR DESCRIPTION
Updates the `1.x` branch docs with a note about `3.0` and fixed a couple links to point to the `README.md` in the `1.x` branch for consistency.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
