### PR TITLE
ISDK-2749: VideoTracks might not be rendered in QS example.

### DIFF
--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -301,16 +301,37 @@ class ViewController: UIViewController {
         }
     }
     
-    func cleanupRemoteParticipant() {
-        if ((self.remoteParticipant) != nil) {
-            if ((self.remoteParticipant?.videoTracks.count)! > 0) {
-                let remoteVideoTrack = self.remoteParticipant?.remoteVideoTracks[0].remoteTrack
-                remoteVideoTrack?.removeRenderer(self.remoteView!)
-                self.remoteView?.removeFromSuperview()
-                self.remoteView = nil
+    func renderRemoteParticipant(participant : RemoteParticipant) -> Bool {
+        // This example renders the first subscribed RemoteVideoTrack from the RemoteParticipant.
+        let videoPublications = participant.remoteVideoTracks
+        for publication in videoPublications {
+            if let subscribedVideoTrack = publication.remoteTrack,
+                publication.isTrackSubscribed {
+                setupRemoteVideoView()
+                subscribedVideoTrack.addRenderer(self.remoteView!)
+                self.remoteParticipant = participant
+                return true
             }
         }
-        self.remoteParticipant = nil
+        return false
+    }
+
+    func renderRemoteParticipants(participants : Array<RemoteParticipant>) {
+        for participant in participants {
+            // Find the first renderable track.
+            if participant.remoteVideoTracks.count > 0,
+                renderRemoteParticipant(participant: participant) {
+                break
+            }
+        }
+    }
+
+    func cleanupRemoteParticipant() {
+        if self.remoteParticipant != nil {
+            self.remoteView?.removeFromSuperview()
+            self.remoteView = nil
+            self.remoteParticipant = nil
+        }
     }
     
     func logMessage(messageText: String) {
@@ -339,9 +360,9 @@ extension ViewController : RoomDelegate {
         
         logMessage(messageText: "Connected to room \(room.name) as \(room.localParticipant?.identity ?? "")")
 
-        if (room.remoteParticipants.count > 0) {
-            self.remoteParticipant = room.remoteParticipants[0]
-            self.remoteParticipant?.delegate = self
+        // This example only renders 1 RemoteVideoTrack at a time. Listen for all events to decide which track to render.
+        for remoteParticipant in room.remoteParticipants {
+            remoteParticipant.delegate = self
         }
 
         let cxObserver = callKitCallController.callObserver
@@ -394,18 +415,16 @@ extension ViewController : RoomDelegate {
     }
     
     func participantDidConnect(room: Room, participant: RemoteParticipant) {
-        if (self.remoteParticipant == nil) {
-            self.remoteParticipant = participant
-            self.remoteParticipant?.delegate = self
-        }
-       logMessage(messageText: "Participant \(participant.identity) connected with \(participant.remoteAudioTracks.count) audio and \(participant.remoteVideoTracks.count) video tracks")
+        // Listen for events from all Participants to decide which RemoteVideoTrack to render.
+        participant.delegate = self
+
+        logMessage(messageText: "Participant \(participant.identity) connected with \(participant.remoteAudioTracks.count) audio and \(participant.remoteVideoTracks.count) video tracks")
     }
 
     func participantDidDisconnect(room: Room, participant: RemoteParticipant) {
-        if (self.remoteParticipant == participant) {
-            cleanupRemoteParticipant()
-        }
         logMessage(messageText: "Room \(room.name), Participant \(participant.identity) disconnected")
+
+        // Nothing to do in this example. Subscription events are used to add/remove renderers.
     }
 }
 
@@ -434,27 +453,30 @@ extension ViewController : RemoteParticipantDelegate {
     }
     
     func didSubscribeToVideoTrack(videoTrack: RemoteVideoTrack, publication: RemoteVideoTrackPublication, participant: RemoteParticipant) {
-        // We are subscribed to the remote Participant's video Track. We will start receiving the
-        // remote Participant's video frames now.
-        
-        logMessage(messageText: "Subscribed to video track for Participant \(participant.identity)")
-        
-        if (self.remoteParticipant == participant) {
-            setupRemoteVideoView()
-            videoTrack.addRenderer(self.remoteView!)
+        // The LocalParticipant is subscribed to the RemoteParticipant's video Track. Frames will begin to arrive now.
+
+        logMessage(messageText: "Subscribed to \(publication.trackName) video track for Participant \(participant.identity)")
+
+        if (self.remoteParticipant == nil) {
+            _ = renderRemoteParticipant(participant: participant)
         }
     }
 
     func didUnsubscribeFromVideoTrack(videoTrack: RemoteVideoTrack, publication: RemoteVideoTrackPublication, participant: RemoteParticipant) {
         // We are unsubscribed from the remote Participant's video Track. We will no longer receive the
         // remote Participant's video.
-        
-        logMessage(messageText: "Unsubscribed from video track for Participant \(participant.identity)")
-        
-        if (self.remoteParticipant == participant) {
-            videoTrack.removeRenderer(self.remoteView!)
-            self.remoteView?.removeFromSuperview()
-            self.remoteView = nil
+
+        logMessage(messageText: "Unsubscribed from \(publication.trackName) video track for Participant \(participant.identity)")
+
+        if self.remoteParticipant == participant {
+            cleanupRemoteParticipant()
+
+            // Find another Participant video to render, if possible.
+            if var remainingParticipants = room?.remoteParticipants,
+                let index = remainingParticipants.index(of: participant) {
+                remainingParticipants.remove(at: index)
+                renderRemoteParticipants(participants: remainingParticipants)
+            }
         }
     }
 

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -446,10 +446,11 @@ extension ViewController : RemoteParticipantDelegate {
             cleanupRemoteParticipant()
 
             // Find another Participant video to render, if possible.
-            var remainingParticipants = room?.remoteParticipants
-            let index = remainingParticipants?.index(of: participant)
-            remainingParticipants?.remove(at: index!)
-            renderRemoteParticipants(participants: remainingParticipants!)
+            if var remainingParticipants = room?.remoteParticipants,
+                let index = remainingParticipants.index(of: participant) {
+                remainingParticipants.remove(at: index)
+                renderRemoteParticipants(participants: remainingParticipants)
+            }
         }
     }
 


### PR DESCRIPTION
This PR addresses https://github.com/twilio/video-quickstart-ios/issues/384, where a RemoteVideoTrack might not be rendered. The specific sequence of events that is problematic is when unsubscribing to the old VideoTrack happens after the new VideoTrack is subscribed.

As I looked more closely at the code there were other issues (like some RemoteParticipants not having a delegate). I tried to make the event handling dynamic and flexible so that any time there is remote video to render, the example will attempt to render it instead of sitting idle.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
