### PR TITLE
ISDK-2770 - Added camera cleanup in ViewController's cleanup path

### DIFF
--- a/AVPlayerExample/ViewController.m
+++ b/AVPlayerExample/ViewController.m
@@ -72,6 +72,12 @@ NSString *const kStatusKey   = @"status";
 - (void)dealloc {
     // We are done with AVAudioSession
     [self stopAudioDevice];
+    
+    // We are done with camera
+    if (self.camera) {
+        [self.camera stopCapture];
+        self.camera = nil;
+    }
 }
 
 #pragma mark - UIViewController

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -101,8 +101,6 @@ static size_t kMaximumFramesPerBuffer = 3072;
     self = [super init];
 
     if (self) {
-        [self setupAVAudioSession];
-
         /*
          * Initialize rendering and capturing context. The deviceContext will be be filled in when startRendering or
          * startCapturing gets called.
@@ -121,6 +119,8 @@ static size_t kMaximumFramesPerBuffer = 3072;
         self.capturingContext = malloc(sizeof(AudioCapturerContext));
         memset(self.capturingContext, 0, sizeof(AudioCapturerContext));
         self.capturingContext->bufferList = &_captureBufferList;
+        
+        [self setupAVAudioSession];
 
         // Setup the AVAudioEngine along with the rendering context
         if (![self setupRecordAudioEngine]) {

--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -46,6 +46,14 @@ class ViewController: UIViewController {
 
     static let coreAudioDeviceText = "CoreAudio Device"
     static let engineAudioDeviceText = "AVAudioEngine Device"
+    
+    deinit {
+        // We are done with camera
+        if let camera = self.camera {
+            camera.stopCapture()
+            self.camera = nil
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -53,6 +53,14 @@ class ViewController: UIViewController {
     let kPreviewPadding = CGFloat(10)
     let kTextBottomPadding = CGFloat(4)
     let kMaxRemoteVideos = Int(2)
+    
+    deinit {
+        // We are done with camera
+        if let camera = self.camera {
+            camera.stopCapture()
+            self.camera = nil
+        }
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/MultiPartyExample/MultiPartyViewController.swift
+++ b/MultiPartyExample/MultiPartyViewController.swift
@@ -162,6 +162,14 @@ class MultiPartyViewController: UIViewController {
                 CaptureDeviceUtils.kSimulcastVideoBitrate : CaptureDeviceUtils.kOneToOneVideoBitrate
         }
     }
+    
+    deinit {
+        // We are done with camera
+        if let camera = self.camera {
+            camera.stopCapture()
+            self.camera = nil
+        }
+    }
 
     // MARK:- UIViewController
     override func viewDidLoad() {

--- a/ObjCVideoQuickstart/ViewController.m
+++ b/ObjCVideoQuickstart/ViewController.m
@@ -42,6 +42,14 @@
 
 @implementation ViewController
 
+- (void)dealloc {
+    // We are done with camera
+    if (self.camera) {
+        [self.camera stopCapture];
+        self.camera = nil;
+    }
+}
+
 #pragma mark - UIViewController
 
 - (void)viewDidLoad {

--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -92,8 +92,6 @@ extension ViewController : CXProviderDelegate {
     func provider(_ provider: CXProvider, perform action: CXEndCallAction) {
         NSLog("provider:performEndCallAction:")
 
-        // AudioDevice is enabled by default
-        self.audioDevice.isEnabled = true
         room?.disconnect()
 
         action.fulfill()

--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -73,6 +73,12 @@ class ViewController: UIViewController {
     deinit {
         // CallKit has an odd API contract where the developer must call invalidate or the CXProvider is leaked.
         callKitProvider.invalidate()
+        
+        // We are done with camera
+        if let camera = self.camera {
+            camera.stopCapture()
+            self.camera = nil
+        }
     }
 
     // MARK:- UIViewController

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -40,6 +40,14 @@ class ViewController: UIViewController {
     @IBOutlet weak var roomLine: UIView!
     @IBOutlet weak var roomLabel: UILabel!
     @IBOutlet weak var micButton: UIButton!
+    
+    deinit {
+        // We are done with camera
+        if let camera = self.camera {
+            camera.stopCapture()
+            self.camera = nil
+        }
+    }
 
     // MARK:- UIViewController
     override func viewDidLoad() {


### PR DESCRIPTION
Our ViewControllers were leaking camera resources if the ViewController is used in a multi-view app (e.g. navigation or tab). Added camera cleanup into the ViewController's destruction path to avoid the leaks.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
