### PR TITLE
CLIENT-7473 AudioEngine example does not play music on air pod pro

### DIFF
--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -967,9 +967,9 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
 #pragma mark - NSNotification Observers
 
 - (TVIAudioDeviceContext)deviceContext {
-    if (self.renderingContext->deviceContext) {
+    if (self.renderingContext && self.renderingContext->deviceContext) {
         return self.renderingContext->deviceContext;
-    } else if (self.capturingContext->deviceContext) {
+    } else if (self.capturingContext && self.capturingContext->deviceContext) {
         return self.capturingContext->deviceContext;
     }
     return NULL;

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -519,8 +519,9 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
         // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
         dispatch_async(dispatch_get_main_queue(), ^{
-            TVIAudioFormat *engineFormat = [[TVIAudioFormat alloc] initWithChannels:self.playoutEngine.manualRenderingFormat.channelCount
-                                                                         sampleRate:self.playoutEngine.manualRenderingFormat.sampleRate
+            AVAudioFormat *manualRenderingFormat  = self.playoutEngine.manualRenderingFormat;
+            TVIAudioFormat *engineFormat = [[TVIAudioFormat alloc] initWithChannels:manualRenderingFormat.channelCount
+                                                                         sampleRate:manualRenderingFormat.sampleRate
                                                                     framesPerBuffer:kMaximumFramesPerBuffer];
             if ([engineFormat isEqual:[[self class] activeFormat]]) {
                 if (self.playoutEngine.isRunning) {
@@ -616,8 +617,9 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
         // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
         dispatch_async(dispatch_get_main_queue(), ^{
-            TVIAudioFormat *engineFormat = [[TVIAudioFormat alloc] initWithChannels:self.recordEngine.manualRenderingFormat.channelCount
-                                                                         sampleRate:self.recordEngine.manualRenderingFormat.sampleRate
+            AVAudioFormat *manualRenderingFormat  = self.recordEngine.manualRenderingFormat;
+            TVIAudioFormat *engineFormat = [[TVIAudioFormat alloc] initWithChannels:manualRenderingFormat.channelCount
+                                                                         sampleRate:manualRenderingFormat.sampleRate
                                                                     framesPerBuffer:kMaximumFramesPerBuffer];
             if ([engineFormat isEqual:[[self class] activeFormat]]) {
                 if (self.recordEngine.isRunning) {

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -553,22 +553,20 @@ static size_t kMaximumFramesPerBuffer = 3072;
     @synchronized(self) {
         // If the capturer is runnning, we will not stop the audio unit.
         if (!self.capturingContext->deviceContext) {
-
-            // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (self.playoutFilePlayer.isPlaying) {
-                    [self.playoutFilePlayer stop];
-                }
-                if (self.playoutEngine.isRunning) {
-                    [self.playoutEngine stop];
-                }
-            });
-
             [self stopAudioUnit];
             [self teardownAudioUnit];
         }
-
         self.renderingContext->deviceContext = NULL;
+        
+        // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.playoutFilePlayer.isPlaying) {
+                [self.playoutFilePlayer stop];
+            }
+            if (self.playoutEngine.isRunning) {
+                [self.playoutEngine stop];
+            }
+        });
     }
 
     return YES;
@@ -653,22 +651,20 @@ static size_t kMaximumFramesPerBuffer = 3072;
     @synchronized(self) {
         // If the renderer is runnning, we will not stop the audio unit.
         if (!self.renderingContext->deviceContext) {
-
-            // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
-            dispatch_async(dispatch_get_main_queue(), ^{
-                if (self.recordFilePlayer.isPlaying) {
-                    [self.recordFilePlayer stop];
-                }
-                if (self.recordEngine.isRunning) {
-                    [self.recordEngine stop];
-                }
-            });
-
             [self stopAudioUnit];
             [self teardownAudioUnit];
         }
-
         self.capturingContext->deviceContext = NULL;
+        
+        // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
+        dispatch_async(dispatch_get_main_queue(), ^{
+            if (self.recordFilePlayer.isPlaying) {
+                [self.recordFilePlayer stop];
+            }
+            if (self.recordEngine.isRunning) {
+                [self.recordEngine stop];
+            }
+        });
     }
 
     return YES;

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -75,7 +75,6 @@ static size_t kMaximumFramesPerBuffer = 3072;
 @property (nonatomic, assign, getter=isInterrupted) BOOL interrupted;
 @property (nonatomic, assign) AudioUnit audioUnit;
 @property (nonatomic, assign) AudioBufferList captureBufferList;
-@property (nonatomic, assign, getter=isRestartAudioUnit) BOOL restartAudioUnit;
 
 @property (nonatomic, strong, nullable) TVIAudioFormat *renderingFormat;
 @property (nonatomic, strong, nullable) TVIAudioFormat *capturingFormat;
@@ -1047,8 +1046,6 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
     // Notify Video SDK about the format change
     if (![activeFormat isEqual:_renderingFormat] ||
         ![activeFormat isEqual:_capturingFormat]) {
-
-        _restartAudioUnit = YES;
 
         NSLog(@"Format changed, restarting with %@", activeFormat);
 

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -101,8 +101,6 @@ static size_t kMaximumFramesPerBuffer = 3072;
     self = [super init];
 
     if (self) {
-        [self setupAVAudioSession];
-
         /*
          * Initialize rendering and capturing context. The deviceContext will be be filled in when startRendering or
          * startCapturing gets called.
@@ -126,6 +124,8 @@ static size_t kMaximumFramesPerBuffer = 3072;
         if (![self setupRecordAudioEngine]) {
             NSLog(@"Failed to setup AVAudioEngine");
         }
+        
+        [self setupAVAudioSession];
     }
 
     return self;
@@ -357,7 +357,7 @@ static size_t kMaximumFramesPerBuffer = 3072;
 }
 
 - (AVAudioPCMBuffer *)musicBuffer {
-    if (_musicBuffer) {
+    if (!_musicBuffer) {
         NSString *fileName = [NSString stringWithFormat:@"%@/%@", [[NSBundle mainBundle] bundlePath], @"mixLoop.caf"];
         NSURL *url = [NSURL fileURLWithPath:fileName];
         AVAudioFile *file = [[AVAudioFile alloc] initForReading:url error:nil];
@@ -975,9 +975,9 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
 #pragma mark - NSNotification Observers
 
 - (TVIAudioDeviceContext)deviceContext {
-    if (self.renderingContext && self.renderingContext->deviceContext) {
+    if (self.renderingContext->deviceContext) {
         return self.renderingContext->deviceContext;
-    } else if (self.capturingContext && self.capturingContext->deviceContext) {
+    } else if (self.capturingContext->deviceContext) {
         return self.capturingContext->deviceContext;
     }
     return NULL;

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -519,16 +519,22 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
         // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (self.playoutFilePlayer.isPlaying) {
-                [self.playoutFilePlayer stop];
-            }
-            if (self.playoutEngine.isRunning) {
-                [self.playoutEngine stop];
-            }
-
-            NSError *error = nil;
-            if (![self.playoutEngine startAndReturnError:&error]) {
-                NSLog(@"Failed to start AVAudioEngine, error = %@", error);
+            TVIAudioFormat *engineFormat = [[TVIAudioFormat alloc] initWithChannels:self.playoutEngine.manualRenderingFormat.channelCount
+                                                                         sampleRate:self.playoutEngine.manualRenderingFormat.sampleRate
+                                                                    framesPerBuffer:kMaximumFramesPerBuffer];
+            if ([engineFormat isEqual:[[self class] activeFormat]]) {
+                if (self.playoutEngine.isRunning) {
+                    [self.playoutEngine stop];
+                }
+                
+                NSError *error = nil;
+                if (![self.playoutEngine startAndReturnError:&error]) {
+                    NSLog(@"Failed to start AVAudioEngine, error = %@", error);
+                }
+            } else {
+                [self teardownPlayoutFilePlayer];
+                [self teardownPlayoutAudioEngine];
+                [self setupPlayoutAudioEngine];
             }
         });
 
@@ -612,16 +618,22 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
         // We will make sure AVAudioEngine and AVAudioPlayerNode is accessed on the main queue.
         dispatch_async(dispatch_get_main_queue(), ^{
-            if (self.recordFilePlayer.isPlaying) {
-                [self.recordFilePlayer stop];
-            }
-            if (self.recordEngine.isRunning) {
-                [self.recordEngine stop];
-            }
-
-            NSError *error = nil;
-            if (![self.recordEngine startAndReturnError:&error]) {
-                NSLog(@"Failed to start AVAudioEngine, error = %@", error);
+            TVIAudioFormat *engineFormat = [[TVIAudioFormat alloc] initWithChannels:self.recordEngine.manualRenderingFormat.channelCount
+                                                                         sampleRate:self.recordEngine.manualRenderingFormat.sampleRate
+                                                                    framesPerBuffer:kMaximumFramesPerBuffer];
+            if ([engineFormat isEqual:[[self class] activeFormat]]) {
+                if (self.recordEngine.isRunning) {
+                    [self.recordEngine stop];
+                }
+                
+                NSError *error = nil;
+                if (![self.recordEngine startAndReturnError:&error]) {
+                    NSLog(@"Failed to start AVAudioEngine, error = %@", error);
+                }
+            } else {
+                [self teardownRecordFilePlayer];
+                [self teardownRecordAudioEngine];
+                [self setupRecordAudioEngine];
             }
         });
 

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -374,6 +374,7 @@ static size_t kMaximumFramesPerBuffer = 3072;
         BOOL success = [file readIntoBuffer:_musicBuffer error:&error];
         if (!success) {
             NSLog(@"Failed to read audio file into buffer. error = %@", error);
+            _musicBuffer = nil;
         }
     }
     return _musicBuffer;
@@ -1099,15 +1100,6 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
             TVIAudioDeviceContext context = [self deviceContext];
             if (context) {
                 TVIAudioDeviceFormatChanged(context);
-
-                TVIAudioDeviceExecuteWorkerBlock(context, ^{
-                    // Restart the AVAudioEngine with new format
-                    TVIAudioFormat *activeFormat = [[self class] activeFormat];
-                    if (![activeFormat isEqual:self->_renderingFormat]) {
-                        [self teardownAudioEngine];
-                        [self setupAudioEngine];
-                    }
-                });
             }
         }
     }

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -101,6 +101,8 @@ static size_t kMaximumFramesPerBuffer = 3072;
     self = [super init];
 
     if (self) {
+        [self setupAVAudioSession];
+
         /*
          * Initialize rendering and capturing context. The deviceContext will be be filled in when startRendering or
          * startCapturing gets called.
@@ -120,8 +122,6 @@ static size_t kMaximumFramesPerBuffer = 3072;
         memset(self.capturingContext, 0, sizeof(AudioCapturerContext));
         self.capturingContext->bufferList = &_captureBufferList;
         
-        [self setupAVAudioSession];
-
         // Setup the AVAudioEngine along with the rendering context
         if (![self setupRecordAudioEngine]) {
             NSLog(@"Failed to setup AVAudioEngine");


### PR DESCRIPTION
This pull request fixes the bug reported by https://github.com/twilio/video-quickstart-ios/issues/456 ticket.

### Description 

When an iPhone is connected to Airpod pro (or any other BT device) `ExampleAVAudioEngineDevice`, and when format change occurs, audio device was not applying the new format on the record and playout `AVAudioEngine`s. As a result, on BT device the audio was playing distorted.

Apparently there is no way to apply format changes on AVAudioEngine while its running - you will have to tear down and set up the AVAudioEngine again.

To fix the problem, the PR checks in `startRendering` and `startCapturing` callbacks - if the active audio format doesn't match with AVAudioEngine's audio format than teardown and setup the AVAudioEngine again, otherwise just restart the audio engine.


### Breakdown 
1. Implemented the fix described above in `startRendering` and `startCapturing` callback.
2. Removed an unused property `restartAudioUnit` 
3. While working on this bug, I encountered another bug where the audio device was not stopping the capture playout music file node when call gets terminated. As a result, if you disconnect and connect again, the remote participant won't be able to hear the music.

### Testing

Manual testing performed with `air pod pro`


**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.




