### PR TITLE
Consume iOS 3.4.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,1 +1,1 @@
-github "twilio/twilio-video-ios" ~> 3.3
+github "twilio/twilio-video-ios" ~> 3.4

--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 3.3'
+  pod 'TwilioVideo', '~> 3.4'
 
   target 'ARKitExample' do
     platform :ios, '11.0'


### PR DESCRIPTION
Update the Quickstart dependency managers to consume TwilioVideo iOS `3.4.0`.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
