### PR TITLE
ISDK-2938: Ensure Quickstart apps work when built with Xcode 12 and run on iOS 14

### DIFF
--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -379,7 +379,11 @@ class ViewController: UIViewController {
         self.room = nil
         self.localAudioTrack = nil
         self.localVideoTrack = nil
-        self.camera?.previewView?.removeFromSuperview()
+
+        if let camera = self.camera {
+            camera.previewView?.removeFromSuperview()
+            camera.stopCapture()
+        }
         self.camera = nil;
     }
 

--- a/VideoQuickStart/SceneDelegate.swift
+++ b/VideoQuickStart/SceneDelegate.swift
@@ -10,7 +10,7 @@ import UIKit
 import TwilioVideo
 
 // Xcode 10.x will compile SceneDelegate even with the availability macro in place.
-#if XCODE_1100
+#if !XCODE_1000
 
 @available(iOS 13.0, *)
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {

--- a/VideoQuickStart/SceneDelegate.swift
+++ b/VideoQuickStart/SceneDelegate.swift
@@ -9,9 +9,6 @@
 import UIKit
 import TwilioVideo
 
-// Xcode 10.x will compile SceneDelegate even with the availability macro in place.
-#if !XCODE_1000
-
 @available(iOS 13.0, *)
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -55,5 +52,3 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     }
     
 }
-#endif
-

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -211,14 +211,11 @@ class ViewController: UIViewController {
         if (frontCamera != nil || backCamera != nil) {
 
             let options = CameraSourceOptions { (builder) in
-                // To support building with Xcode 10.x.
-                #if XCODE_1100
                 if #available(iOS 13.0, *) {
                     // Track UIWindowScene events for the key window's scene.
                     // The example app disables multi-window support in the .plist (see UIApplicationSceneManifestKey).
                     builder.orientationTracker = UserInterfaceTracker(scene: UIApplication.shared.keyWindow!.windowScene!)
                 }
-                #endif
             }
             // Preview our local camera track in the local video preview view.
             camera = CameraSource(options: options, delegate: self)


### PR DESCRIPTION
This PR fixes a few issues in the Quickstarts that were found when testing with Xcode 12 Beta 2 and iOS 14 Beta 2

1. The CameraSource was not being shutdown properly when switching audio devices in the Audio Device Example app
2. The SceneDelegate in the VideoQuickstart was not being compiled under Xcode 12. Tweaked the Macro used to skip the file with Xcode 10.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
