### PR TITLE
Consume 2.12.0

### DIFF
--- a/Podfile
+++ b/Podfile
@@ -3,7 +3,7 @@ source 'https://github.com/CocoaPods/Specs'
 workspace 'VideoQuickStart'
 
 abstract_target 'TwilioVideo' do
-  pod 'TwilioVideo', '~> 2.11'
+  pod 'TwilioVideo', '~> 2.12'
 
   target 'ARKitExample' do
     platform :ios, '11.0'


### PR DESCRIPTION
Update to consume the `2.12.0` release of the iOS SDK.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
