### PR TITLE
ISDK-3059: Add text about the requirement for Client-side Room Creation enabled.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ This repository contains example code written in both Objective-C and Swift. The
 
 If you haven't used Twilio before, welcome! You'll need to [Sign up for a Twilio account](https://www.twilio.com/try-twilio) first. It's free!
 
+These Quickstarts expect that you have "Client-side Room Creation" enabled in your Twilio account. You can check this setting on the [Default Room Settings](https://www.twilio.com/console/video/configure) page in the [Twilio Console](https://www.twilio.com/console).
+
 ### CocoaPods
 
 1. Install [CocoaPods 1.7.5 or newer](https://guides.cocoapods.org/using/getting-started.html).


### PR DESCRIPTION
Document that the quickstarts require the `Client-side Room Creation` setting enabled.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
