### PR TITLE
ISDK-3191 - Play continuous music before-during-and-after the call

### DIFF
--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.h
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.h
@@ -13,6 +13,6 @@ NS_CLASS_AVAILABLE(NA, 11_0)
 - (void)playMusic;
 
 - (void)playContinuousMusic;
-- (void)stopContinuousMusic;
+- (void)tearDownAudio;
 
 @end

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.h
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.h
@@ -12,4 +12,7 @@ NS_CLASS_AVAILABLE(NA, 11_0)
 
 - (void)playMusic;
 
+- (void)playContinuousMusic;
+- (void)stopContinuousMusic;
+
 @end

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.h
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.h
@@ -10,9 +10,17 @@
 NS_CLASS_AVAILABLE(NA, 11_0)
 @interface ExampleAVAudioEngineDevice : NSObject <TVIAudioDevice>
 
-- (void)playMusic;
-
-- (void)playContinuousMusic;
-- (void)tearDownAudio;
+/**
+ *  @brief This method is invoked when client wish to play music using the AVAudioEngine and CoreAudio
+ *
+ *  @param continuous Continue playing music after the disconnect.
+ *
+ *  @discussion Your app can play music before connecting a Room, while in a Room or after the disconnect.
+ *  If you wish to play music irespective of you are connected to a Room or not (before [TwilioVideo connect:] or
+ *  after [room disconnect]), or wish to continue playing music after disconnected from a Room, set the `continuous`
+ *  argument to `YES`.
+ *  If the `continuous` is set to `NO`, the audio device will not continue playing the music once you disconnect from the Room.
+ */
+- (void)playMusic:(BOOL)continuous;
 
 @end

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -445,8 +445,8 @@ static size_t kMaximumFramesPerBuffer = 3072;
             TVIAudioDeviceContext *context = NULL;
             [self startRendering:context];
             [self startCapturing:context];
-            self.continuousMusic = continuous;
         }
+        self.continuousMusic = continuous;
     }
     dispatch_async(dispatch_get_main_queue(), ^{
         [self scheduleMusicOnPlayoutEngine];

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -437,6 +437,12 @@ static size_t kMaximumFramesPerBuffer = 3072;
 - (void)playMusic:(BOOL)continuous {
     @synchronized(self) {
         if (![self deviceContext]) {
+            if (!self.renderingFormat) {
+                self.renderingFormat = [self renderFormat];
+            }
+            if (!self.capturingFormat) {
+                self.capturingFormat = [self captureFormat];
+            }
             // If device context is null, we will setup the audio unit by invoking the
             // rendring and capturing.
             [self initializeCapturer];

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -436,7 +436,7 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
 - (void)playMusic:(BOOL)continuous {
     @synchronized(self) {
-        if (![self deviceContext]) {
+        if (continuous) {
             if (!self.renderingFormat) {
                 self.renderingFormat = [self renderFormat];
             }
@@ -612,7 +612,6 @@ static size_t kMaximumFramesPerBuffer = 3072;
         
         // Continue playing music even after disconnected from a Room.
         if (self.continuousMusic) {
-            self.renderingContext->deviceContext = NULL;
             return YES;
         }
         
@@ -721,7 +720,6 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
         // Continue playing music even after disconnected from a Room.
         if (self.continuousMusic) {
-            self.capturingContext->deviceContext = NULL;
             return YES;
         }
 

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -440,9 +440,10 @@ static size_t kMaximumFramesPerBuffer = 3072;
     });
 }
 
-- (void)stopContinuousMusic {
+- (void)tearDownAudio {
     [self teardownAudioUnit];
     [self teardownAudioEngine];
+    self.continuousMusic = NO;
 }
 
 - (void)attachMusicNodeToEngine:(AVAudioEngine *)engine {
@@ -690,6 +691,12 @@ static size_t kMaximumFramesPerBuffer = 3072;
 
 - (BOOL)stopCapturing {
     @synchronized(self) {
+
+        // Continue playing music even after disconnected from a Room.
+        if (self.continuousMusic) {
+            return YES;
+        }
+
         // If the renderer is runnning, we will not stop the audio unit.
         if (!self.renderingContext->deviceContext) {
             [self stopAudioUnit];


### PR DESCRIPTION
This Pull Request adds functionality in ExampleAVAudioEngineAudioDevice to play continuous music before connecting to a Room, while in a Room, or after disconnect. The PR adds two APIs in ExampleAVAudioEngineAudioDevice which can be used to start and stop the continuous music using the core audio. The ExampleAVAudioEngineAudioDevice uses `continuousMusic` flag to determine if it should continue playing music or not.

To play continuous music, the PR establishes the core audio upon continuousMusic request is received by ExampleAVAudioEngineAudioDevice.

While validating the audio route change, I ran into the following 100% reproducible error when call is not connected to the Room and music is being played by the same core audio -

```
02-02 22:47:43.653057-0800 AudioDeviceExample[37879:6664359] Expected 1156 frames but got 1536.
2021-02-02 22:47:43.653469-0800 AudioDeviceExample[37879:6664359] kAudioUnitErr_TooManyFramesToProcess : inFramesToProcess=1536, mMaxFramesPerSlice=1156
2021-02-02 22:47:43.653663-0800 AudioDeviceExample[37879:6664359] Can handle a max of 1156 frames but got 1536.
2021-02-02 22:47:43.685026-0800 AudioDeviceExample[37879:6664359] Expected 1156 frames but got 1536.
2021-02-02 22:47:43.685248-0800 AudioDeviceExample[37879:6664359] Can handle a max of 1156 frames but got 1536.
2021-02-02 22:47:43.717022-0800 AudioDeviceExample[37879:6664359] Expected 1156 frames but got 1536.
```

I have fixed this error by setting the kAudioUnitProperty_MaximumFramesPerSlice but we can discuss the fix during code review.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
