### PR TITLE
VIDEO-6636: Consume video-ios-4.6.0

### DIFF
--- a/ARKitExample.xcodeproj/project.pbxproj
+++ b/ARKitExample.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AVPlayerExample.xcodeproj/project.pbxproj
+++ b/AVPlayerExample.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioDeviceExample.xcodeproj/project.pbxproj
+++ b/AudioDeviceExample.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioSinkExample.xcodeproj/project.pbxproj
+++ b/AudioSinkExample.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DataTrackExample.xcodeproj/project.pbxproj
+++ b/DataTrackExample.xcodeproj/project.pbxproj
@@ -441,7 +441,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ObjCVideoQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVideoQuickstart.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReplayKitExample.xcodeproj/project.pbxproj
+++ b/ReplayKitExample.xcodeproj/project.pbxproj
@@ -826,7 +826,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ScreenCapturerExample.xcodeproj/project.pbxproj
+++ b/ScreenCapturerExample.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoCallKitQuickStart.xcodeproj/project.pbxproj
+++ b/VideoCallKitQuickStart.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 			repositoryURL = "git@github.com:twilio/twilio-video-ios.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoQuickStart.xcodeproj/project.pbxproj
+++ b/VideoQuickStart.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 			repositoryURL = "git@github.com:twilio/twilio-video-ios.git";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 4.5.0;
+				minimumVersion = 4.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
- Increment version to 4.6.0 using `bump_spm_version.sh`.
- Did not change project files, they were properly configured. (Setting  `ONLY_ACTIVE_ARCH = YES` for debug builds is valid and saves time).

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
