### PR TITLE
VIDEO-4533

### DIFF
--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -447,10 +447,9 @@ static size_t kMaximumFramesPerBuffer = 3072;
             // rendring and capturing.
             [self initializeCapturer];
             [self initializeRenderer];
-            
-            TVIAudioDeviceContext *context = NULL;
-            [self startRendering:context];
-            [self startCapturing:context];
+        
+            [self startRendering:self.renderingContext->deviceContext];
+            [self startCapturing:self.capturingContext->deviceContext];
         }
         self.continuousMusic = continuous;
     }


### PR DESCRIPTION
When we restart the record and playout engine with the music file the context was not valid. So passing the valid device context during start capture and start rendering. 

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
