### PR TITLE
VIDEO-5099 Crash fix when second participant joins

### DIFF
--- a/AudioDeviceExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/AudioDeviceExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:AudioDeviceExample.xcodeproj">
+      location = "self:">
    </FileRef>
 </Workspace>

--- a/AudioDeviceExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/AudioDeviceExample.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,6 @@
 <Workspace
    version = "1.0">
    <FileRef
-      location = "self:">
+      location = "self:AudioDeviceExample.xcodeproj">
    </FileRef>
 </Workspace>

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -797,6 +797,10 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
     }
 
     AudioCapturerContext *context = (AudioCapturerContext *)refCon;
+    
+    if (context->deviceContext == NULL) {
+        return noErr;
+    }
 
     AudioBufferList *audioBufferList = context->bufferList;
     audioBufferList->mBuffers[0].mDataByteSize = numFrames * sizeof(UInt16) * kPreferredNumberOfChannels;
@@ -948,7 +952,7 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
         NSLog(@"Could not set stream format on output bus!");
         return NO;
     }
-
+    
     // Enable the microphone input
     UInt32 enableInput = 1;
     status = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO,

--- a/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
+++ b/AudioDeviceExample/AudioDevices/ExampleAVAudioEngineDevice.m
@@ -952,7 +952,6 @@ static OSStatus ExampleAVAudioEngineDeviceRecordCallback(void *refCon,
         NSLog(@"Could not set stream format on output bus!");
         return NO;
     }
-    
     // Enable the microphone input
     UInt32 enableInput = 1;
     status = AudioUnitSetProperty(_audioUnit, kAudioOutputUnitProperty_EnableIO,


### PR DESCRIPTION
1. Fixed a crash when the second participant joins the room and capture context is not established.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
