### PR TITLE
Update TwilioVideo SDK to 5.1

### DIFF
--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -159,12 +159,17 @@ class ViewController: UIViewController {
                 builder.audioTracks = [audioTrack]
             }
 
-            // Use the preferred codecs
+            // Use the preferred audio codec
             if let preferredAudioCodec = Settings.shared.audioCodec {
                 builder.preferredAudioCodecs = [preferredAudioCodec]
             }
-            if let preferredVideoCodec = Settings.shared.videoCodec {
-                builder.preferredVideoCodecs = [preferredVideoCodec]
+
+            // Use Adpative Simulcast by setting builer.videoEncodingMode to .auto if preferredVideoCodec is .auto (default). The videoEncodingMode API is mutually exclusive with existing codec management APIs EncodingParameters.maxVideoBitrate and preferredVideoCodecs
+            let preferredVideoCodec = Settings.shared.videoCodec
+            if preferredVideoCodec == .auto {
+                builder.videoEncodingMode = .auto
+            } else if let codec = preferredVideoCodec.codec {
+                builder.preferredVideoCodecs = [codec]
             }
 
             // Use the preferred encoding parameters

--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -95,12 +95,17 @@ class ViewController: UIViewController {
                 builder.videoTracks = [videoTrack]
             }
 
-            // Use the preferred codecs
+            // Use the preferred audio codec
             if let preferredAudioCodec = Settings.shared.audioCodec {
                 builder.preferredAudioCodecs = [preferredAudioCodec]
             }
-            if let preferredVideoCodec = Settings.shared.videoCodec {
-                builder.preferredVideoCodecs = [preferredVideoCodec]
+
+            // Use Adpative Simulcast by setting builer.videoEncodingMode to .auto if preferredVideoCodec is .auto (default). The videoEncodingMode API is mutually exclusive with existing codec management APIs EncodingParameters.maxVideoBitrate and preferredVideoCodecs
+            let preferredVideoCodec = Settings.shared.videoCodec
+            if preferredVideoCodec == .auto {
+                builder.videoEncodingMode = .auto
+            } else if let codec = preferredVideoCodec.codec {
+                builder.preferredVideoCodecs = [codec]
             }
 
             // Use the preferred encoding parameters

--- a/ObjCVideoQuickstart/ViewController.m
+++ b/ObjCVideoQuickstart/ViewController.m
@@ -217,6 +217,7 @@
         // Use the local media that we prepared earlier.
         builder.audioTracks = self.localAudioTrack ? @[ self.localAudioTrack ] : @[ ];
         builder.videoTracks = self.localVideoTrack ? @[ self.localVideoTrack ] : @[ ];
+        builder.videoEncodingMode = TVIVideoEncodingModeAuto;
 
         // The name of the Room where the Client will attempt to connect to. Please note that if you pass an empty
         // Room `name`, the Client will create one for you. You can get the name or sid from any connected Room.

--- a/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
+++ b/ReplayKitExample/ReplayKitExample/ReplayKitVideoSource.swift
@@ -155,18 +155,28 @@ class ReplayKitVideoSource: NSObject, VideoSource {
     ///   - isScreencast: If the content is a screencast or not.
     ///   - telecineOptions: The options used to process the input frames.
     /// - Returns: The EncodingParameters and VideoFormat that are appropriate for the use case.
-    static public func getParametersForUseCase(codec: VideoCodec, isScreencast: Bool, telecineOptions: TelecineOptions) -> (EncodingParameters, VideoFormat) {
+    static public func getParametersForUseCase(videoCodec: VideoCodec, isScreencast: Bool, telecineOptions: TelecineOptions) -> (EncodingParameters, VideoFormat) {
         let audioBitrate = UInt(0)
         var videoBitrate = kMaxVideoBitrate
         var maxWidthOrHeight = isScreencast ? UInt(0) : kDownScaledMaxWidthOrHeight
         // TODO: IVTC in broadcast
         let maxFrameRate = isScreencast ? kMaxVideoFrameRate : UInt(30)
 
-        if let vp8Codec = codec as? Vp8Codec {
-            videoBitrate = vp8Codec.isSimulcast ? kMaxVideoBitrateSimulcast : kMaxVideoBitrate
+        switch videoCodec {
+        case .auto:
+            videoBitrate = 0
+        case .VP8:
+            videoBitrate = kMaxVideoBitrate
             if (!isScreencast) {
-                maxWidthOrHeight = vp8Codec.isSimulcast ? kDownScaledMaxWidthOrHeightSimulcast : kDownScaledMaxWidthOrHeight
+                maxWidthOrHeight = kDownScaledMaxWidthOrHeight
             }
+        case .VP8Simulcast:
+            videoBitrate = kMaxVideoBitrateSimulcast
+            if (!isScreencast) {
+                maxWidthOrHeight = kDownScaledMaxWidthOrHeightSimulcast
+            }
+        default:
+            break
         }
 
         return (EncodingParameters(audioBitrate: audioBitrate, videoBitrate: videoBitrate),

--- a/ReplayKitExample/ReplayKitExample/ViewController.swift
+++ b/ReplayKitExample/ReplayKitExample/ViewController.swift
@@ -335,7 +335,7 @@ class ViewController: UIViewController {
                 self.spinner.startAnimating()
                 self.infoLabel?.isHidden = true
                 let (encodingParams, _) = ReplayKitVideoSource.getParametersForUseCase(
-                    codec: Settings.shared.videoCodec ?? Vp8Codec()!,
+                    videoCodec: Settings.shared.videoCodec,
                     isScreencast: !ViewController.kDownscaleBuffers,
                     telecineOptions: .disabled
                 )
@@ -359,12 +359,17 @@ class ViewController: UIViewController {
                 builder.videoTracks = [videoTrack]
             }
 
-            // Use the preferred codecs
+            // Use the preferred audio codec
             if let preferredAudioCodec = Settings.shared.audioCodec {
                 builder.preferredAudioCodecs = [preferredAudioCodec]
             }
-            if let preferredVideoCodec = Settings.shared.videoCodec {
-                builder.preferredVideoCodecs = [preferredVideoCodec]
+
+            // Use Adpative Simulcast by setting builer.videoEncodingMode to .auto if preferredVideoCodec is .auto (default). The videoEncodingMode API is mutually exclusive with existing codec management APIs EncodingParameters.maxVideoBitrate and preferredVideoCodecs
+            let preferredVideoCodec = Settings.shared.videoCodec
+            if preferredVideoCodec == .auto {
+                builder.videoEncodingMode = .auto
+            } else if let codec = preferredVideoCodec.codec {
+                builder.preferredVideoCodecs = [codec]
             }
 
             // Use the preferred encoding parameters

--- a/Utils/SettingsTableViewController.swift
+++ b/Utils/SettingsTableViewController.swift
@@ -84,9 +84,7 @@ class SettingsTableViewController: UITableViewController {
                     detailText = codec.name
                 }
             case SettingsTableViewController.videoCodecLabel:
-                if let codec = settings.videoCodec {
-                    detailText = self.getDisplayStrForVideoCodec(codec: codec)
-                }
+                detailText = settings.videoCodec.name
             case SettingsTableViewController.maxAudioBitrateLabel:
                 detailText = String(settings.maxAudioBitrate)
             case SettingsTableViewController.maxVideoBitrateLabel:
@@ -234,34 +232,22 @@ class SettingsTableViewController: UITableViewController {
     func didSelectVideoCodecRow(indexPath: IndexPath) {
         var selectedButton : UIAlertAction!
         
-        let defaultButton = UIAlertAction(title: "Default", style: .default, handler: { (action) -> Void in
-            self.settings.videoCodec = nil
-            self.reloadSelectedRowOrTableView()
-        })
-        
         let alertController = UIAlertController(title: self.labels[indexPath.section][indexPath.row], message: nil, preferredStyle: .actionSheet)
-        let selectionArray = settings.supportedVideoCodecs
         
-        for codec in selectionArray {
-            let selectionButton = UIAlertAction(title: self.getDisplayStrForVideoCodec(codec: codec),
+        for videoCodec in VideoCodec.allCases {
+            let selectionButton = UIAlertAction(title: videoCodec.name,
                                                 style: .default,
                                                 handler: { (action) -> Void in
-                self.settings.videoCodec = codec
+                self.settings.videoCodec = videoCodec
                 self.reloadSelectedRowOrTableView()
             })
             
-            if (settings.videoCodec == codec) {
+            if (settings.videoCodec == videoCodec) {
                 selectedButton = selectionButton;
             }
             
             alertController.addAction(selectionButton)
         }
-        
-        if selectedButton == nil {
-            selectedButton = defaultButton;
-        }
-        
-        alertController.addAction(defaultButton)
         
         if UIDevice.current.userInterfaceIdiom == .pad {
             alertController.popoverPresentationController?.sourceView = tableView.cellForRow(at: indexPath)
@@ -336,14 +322,5 @@ class SettingsTableViewController: UITableViewController {
             alertController.popoverPresentationController?.sourceRect = (tableView.cellForRow(at: indexPath)?.bounds)!
         }
         self.navigationController!.present(alertController, animated: true, completion: nil)
-    }
-
-    func getDisplayStrForVideoCodec(codec: VideoCodec) -> String {
-        var str = codec.name
-
-        if let vp8Codec = codec as? Vp8Codec {
-            str += vp8Codec.isSimulcast ? " Simulcast" : ""
-        }
-        return str;
     }
 }

--- a/VideoCallKitQuickStart/ViewController+CallKit.swift
+++ b/VideoCallKitQuickStart/ViewController+CallKit.swift
@@ -178,9 +178,12 @@ extension ViewController {
                 builder.preferredAudioCodecs = [preferredAudioCodec]
             }
             
-            // Use the preferred video codec
-            if let preferredVideoCodec = Settings.shared.videoCodec {
-                builder.preferredVideoCodecs = [preferredVideoCodec]
+            // Use Adpative Simulcast by setting builer.videoEncodingMode to .auto if preferredVideoCodec is .auto (default). The videoEncodingMode API is mutually exclusive with existing codec management APIs EncodingParameters.maxVideoBitrate and preferredVideoCodecs
+            let preferredVideoCodec = Settings.shared.videoCodec
+            if preferredVideoCodec == .auto {
+                builder.videoEncodingMode = .auto
+            } else if let codec = preferredVideoCodec.codec {
+                builder.preferredVideoCodecs = [codec]
             }
             
             // Use the preferred encoding parameters

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -143,9 +143,12 @@ class ViewController: UIViewController {
                 builder.preferredAudioCodecs = [preferredAudioCodec]
             }
             
-            // Use the preferred video codec
-            if let preferredVideoCodec = Settings.shared.videoCodec {
-                builder.preferredVideoCodecs = [preferredVideoCodec]
+            // Use Adpative Simulcast by setting builer.videoEncodingMode to .auto if preferredVideoCodec is .auto (default). The videoEncodingMode API is mutually exclusive with existing codec management APIs EncodingParameters.maxVideoBitrate and preferredVideoCodecs
+            let preferredVideoCodec = Settings.shared.videoCodec
+            if preferredVideoCodec == .auto {
+                builder.videoEncodingMode = .auto
+            } else if let codec = preferredVideoCodec.codec {
+                builder.preferredVideoCodecs = [codec]
             }
             
             // Use the preferred encoding parameters


### PR DESCRIPTION
#### 5.1.0

Features

- This release introduces Adaptive Simulcast along with new Video Encoding modes for publishers. Adaptive Simulcast reduces publisher resource usage by only sending those encodings for a video track that are needed by subscribers or by the media server (when recording is enabled). This is an opt-in feature and can be enabled by setting the new Connect Option `videoEncodingMode` to `auto`, which allows the SDK to select video codecs, use adaptive simulcast and manage encodings automatically.

API Changes

- Added the `videoEncodingMode` property to `ConnectOptions`. 
- The `videoEncodingMode` API is mutually exclusive with existing codec management APIs `EncodingParameters.maxVideoBitrate` and `preferredVideoCodecs`.

Known Issues

- Audio playback fails in some cases when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

Size Impact

Architecture | Compressed Size | Uncompressed Size
------------ | --------------- | -----------------
Universal | 4.8 MB | 11.4 MB
arm64 | 4.8 MB | 11.4 MB