### PR TITLE
Change C to c in camera name. 

### DIFF
--- a/VideoCallKitQuickStart/ViewController.swift
+++ b/VideoCallKitQuickStart/ViewController.swift
@@ -220,7 +220,7 @@ class ViewController: UIViewController {
         if (frontCamera != nil || backCamera != nil) {
             // Preview our local camera track in the local video preview view.
             camera = CameraSource(delegate: self)
-            localVideoTrack = LocalVideoTrack(source: camera!, enabled: true, name: "Camera")
+            localVideoTrack = LocalVideoTrack(source: camera!, enabled: true, name: "camera")
 
             // Add renderer to video track for local preview
             localVideoTrack!.addRenderer(self.previewView)

--- a/VideoQuickStart/ViewController.swift
+++ b/VideoQuickStart/ViewController.swift
@@ -238,7 +238,7 @@ class ViewController: UIViewController {
             }
             // Preview our local camera track in the local video preview view.
             camera = CameraSource(options: options, delegate: self)
-            localVideoTrack = LocalVideoTrack(source: camera!, enabled: true, name: "Camera")
+            localVideoTrack = LocalVideoTrack(source: camera!, enabled: true, name: "camera")
 
             // Add renderer to video track for local preview
             localVideoTrack!.addRenderer(self.previewView)


### PR DESCRIPTION
This was a source of a bug for our app following this same convention where if we used a capital C for the camera name the remote participant could not see our camera.  I followed some similar post from previous issues on and this led me to this change.  After this change was made the remote could see our camera and everything worked. 

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x ] I acknowledge that all my contributions will be made under the project's license.
