### PR TITLE
Update Video iOS SDK to 5.8.0

### DIFF
--- a/ARKitExample.xcodeproj/project.pbxproj
+++ b/ARKitExample.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AVPlayerExample.xcodeproj/project.pbxproj
+++ b/AVPlayerExample.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioDeviceExample.xcodeproj/project.pbxproj
+++ b/AudioDeviceExample.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioSinkExample.xcodeproj/project.pbxproj
+++ b/AudioSinkExample.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DataTrackExample.xcodeproj/project.pbxproj
+++ b/DataTrackExample.xcodeproj/project.pbxproj
@@ -441,7 +441,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ObjCVideoQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVideoQuickstart.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReplayKitExample.xcodeproj/project.pbxproj
+++ b/ReplayKitExample.xcodeproj/project.pbxproj
@@ -826,7 +826,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReplayKitExample/BroadcastExtension/ExampleReplayKitAudioCapturer.m
+++ b/ReplayKitExample/BroadcastExtension/ExampleReplayKitAudioCapturer.m
@@ -102,7 +102,7 @@ static size_t kMaximumFramesPerMicAudioBuffer = 2048;
 
 #pragma mark - Public
 
-dispatch_queue_t ExampleCoreAudioDeviceGetCurrentQueue() {
+dispatch_queue_t ExampleCoreAudioDeviceGetCurrentQueue(void) {
     /*
      * The current dispatch queue is needed in order to synchronize with samples delivered by ReplayKit. Ideally, the
      * ReplayKit APIs would support this use case, but since they do not we use a deprecated API to discover the queue.
@@ -132,7 +132,7 @@ OSStatus ExampleCoreAudioDeviceCapturerCallback(ExampleReplayKitAudioCapturer *c
                                                                    sampleRate:asbd->mSampleRate
                                                               framesPerBuffer:format.framesPerBuffer];
         context->streamDescription = *asbd;
-        TVIAudioDeviceFormatChanged(context->deviceContext);
+        TVIAudioDeviceReinitialize(context->deviceContext);
         return noErr;
     }
 

--- a/ScreenCapturerExample.xcodeproj/project.pbxproj
+++ b/ScreenCapturerExample.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/Utils/Settings.swift
+++ b/Utils/Settings.swift
@@ -40,8 +40,7 @@ enum VideoCodec: CaseIterable {
 class Settings: NSObject {
 
     // ISDK-2644: Resolving a conflict with AudioToolbox in iOS 13
-    let supportedAudioCodecs: [TwilioVideo.AudioCodec] = [IsacCodec(),
-                                                          OpusCodec(),
+    let supportedAudioCodecs: [TwilioVideo.AudioCodec] = [OpusCodec(),
                                                           PcmaCodec(),
                                                           PcmuCodec(),
                                                           G722Codec()]

--- a/VideoCallKitQuickStart.xcodeproj/project.pbxproj
+++ b/VideoCallKitQuickStart.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 			repositoryURL = "git@github.com:twilio/twilio-video-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoQuickStart.xcodeproj/project.pbxproj
+++ b/VideoQuickStart.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 			repositoryURL = "git@github.com:twilio/twilio-video-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.2.0;
+				minimumVersion = 5.8.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
<!-- Describe your Pull Request -->
#### 5.8.0 (February 28, 2024)
Enhancements
- This version contains 'VideoTrackStoringSampleBufferVideoView' class which simplifies the implementation of Picture in Picture.
- This release is based on Chromium WebRTC 112.
- iSAC Codec is no longer supported.

Known Issues
- Audio playback fails in some cases when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
