### PR TITLE
Update Video iOS SDK to 5.8.1

### DIFF
--- a/ARKitExample.xcodeproj/project.pbxproj
+++ b/ARKitExample.xcodeproj/project.pbxproj
@@ -410,7 +410,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AVPlayerExample.xcodeproj/project.pbxproj
+++ b/AVPlayerExample.xcodeproj/project.pbxproj
@@ -414,7 +414,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioDeviceExample.xcodeproj/project.pbxproj
+++ b/AudioDeviceExample.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/AudioSinkExample.xcodeproj/project.pbxproj
+++ b/AudioSinkExample.xcodeproj/project.pbxproj
@@ -443,7 +443,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/DataTrackExample.xcodeproj/project.pbxproj
+++ b/DataTrackExample.xcodeproj/project.pbxproj
@@ -441,7 +441,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ObjCVideoQuickstart.xcodeproj/project.pbxproj
+++ b/ObjCVideoQuickstart.xcodeproj/project.pbxproj
@@ -431,7 +431,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ReplayKitExample.xcodeproj/project.pbxproj
+++ b/ReplayKitExample.xcodeproj/project.pbxproj
@@ -826,7 +826,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/ScreenCapturerExample.xcodeproj/project.pbxproj
+++ b/ScreenCapturerExample.xcodeproj/project.pbxproj
@@ -422,7 +422,7 @@
 			repositoryURL = "https://github.com/twilio/twilio-video-ios";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoCallKitQuickStart.xcodeproj/project.pbxproj
+++ b/VideoCallKitQuickStart.xcodeproj/project.pbxproj
@@ -470,7 +470,7 @@
 			repositoryURL = "git@github.com:twilio/twilio-video-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/VideoQuickStart.xcodeproj/project.pbxproj
+++ b/VideoQuickStart.xcodeproj/project.pbxproj
@@ -460,7 +460,7 @@
 			repositoryURL = "git@github.com:twilio/twilio-video-ios.git";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 5.8.0;
+				minimumVersion = 5.8.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
<!-- Describe your Pull Request -->
#### 5.8.1 (April 19, 2024)

* Programmable Video iOS SDK 5.8.1 [[XCFramework]](https://github.com/twilio/twilio-video-ios/releases/download/5.8.1/TwilioVideo.xcframework.zip) (checksum: XCFRAMEWORK_CHECKSUM).

Enhancements
- The SDK now includes the privacy manifest in the XCFramework. The SDK collects analytic data such as WebRTC stats when the `insightsEnabled` property is enabled in `TVIConnectOptions`.
The [required reason APIs](https://developer.apple.com/documentation/bundleresources/privacy_manifest_files/describing_use_of_required_reason_api) included in the privacy manifest are for internal usage by WebRTC and are not used directly by the Video SDK.
- The SDK XCFramework is now signed with Twilio's distribution signature.

Known Issues
- Audio playback fails in some cases when running a simulator on a Mac Mini. [#182](https://github.com/twilio/twilio-video-ios/issues/182)
- Unpublishing and republishing a `LocalAudioTrack` or `LocalVideoTrack` might not be seen by Participants. [#34](https://github.com/twilio/twilio-video-ios/issues/34)
- H.264 video might become corrupted after a network handoff. [#147](https://github.com/twilio/twilio-video-ios/issues/147)
- iOS devices do not support more than three H.264 encoders. Refer to [#17](https://github.com/twilio/twilio-video-ios/issues/17) for suggested work arounds.
- Publishing H.264 video at greater than 1280x720 @ 30fps is not supported. If a failure occurs then no error is raised to the developer. [ISDK-1590]

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
