### PR TITLE
VBLOCKS-4046 fix layout subview crash

### DIFF
--- a/AudioDeviceExample/ViewController.swift
+++ b/AudioDeviceExample/ViewController.swift
@@ -250,9 +250,15 @@ class ViewController: UIViewController {
 
             let dimensions = previewView.videoDimensions
             var previewBounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 160, height: 160))
-            previewBounds = AVMakeRect(aspectRatio: CGSize(width: CGFloat(dimensions.width),
-                                                           height: CGFloat(dimensions.height)),
-                                       insideRect: previewBounds)
+            if dimensions.width == 0 && dimensions.height == 0 {
+                previewBounds = AVMakeRect(aspectRatio: CGSize(width: CGFloat(160),
+                                                               height: CGFloat(120)),
+                                           insideRect: previewBounds)
+            } else {
+                previewBounds = AVMakeRect(aspectRatio: CGSize(width: CGFloat(dimensions.width),
+                                                               height: CGFloat(dimensions.height)),
+                                           insideRect: previewBounds)
+            }
 
             previewBounds = previewBounds.integral
             previewView.bounds = previewBounds

--- a/AudioSinkExample/ViewController.swift
+++ b/AudioSinkExample/ViewController.swift
@@ -194,9 +194,16 @@ class ViewController: UIViewController {
         if let previewView = self.camera?.previewView {
             let dimensions = previewView.videoDimensions
             var previewBounds = CGRect(origin: CGPoint.zero, size: CGSize(width: 160, height: 160))
-            previewBounds = AVMakeRect(aspectRatio: CGSize(width: CGFloat(dimensions.width),
-                                                           height: CGFloat(dimensions.height)),
-                                       insideRect: previewBounds)
+            
+            if dimensions.width == 0 && dimensions.height == 0 {
+                previewBounds = AVMakeRect(aspectRatio: CGSize(width: CGFloat(160),
+                                                               height: CGFloat(120)),
+                                           insideRect: previewBounds)
+            } else {
+                previewBounds = AVMakeRect(aspectRatio: CGSize(width: CGFloat(dimensions.width),
+                                                               height: CGFloat(dimensions.height)),
+                                           insideRect: previewBounds)
+            }
 
             previewBounds = previewBounds.integral
             previewView.bounds = previewBounds


### PR DESCRIPTION
Fixed a crash when the preview bounds were NaN because the camera permission is still not granted or denied.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
